### PR TITLE
Update SearchBar z-index 하향조정

### DIFF
--- a/src/pages/HomePage/HomePage.module.css
+++ b/src/pages/HomePage/HomePage.module.css
@@ -29,7 +29,7 @@
 
 .searchBar {
   position: fixed;
-  z-index: 1000;
+  z-index: 998;
 }
 
 .mapView {


### PR DESCRIPTION
사유: 다른 모달이 켜져있을 때도 활성화된 것처럼 보이는 것을 완화하기 위함
